### PR TITLE
changing AIP names on quality checker

### DIFF
--- a/.github/quality-checker/main.go
+++ b/.github/quality-checker/main.go
@@ -27,7 +27,7 @@ import (
 )
 
 // The set of checkers that are run on every discovered rule.
-var checkers = []func(aip int, name string) []error{
+var checkers = []func(aep int, name string) []error{
 	checkRuleDocumented,
 	checkRuleName,
 	checkRuleRegistered,
@@ -54,32 +54,32 @@ func main() {
 			func(p string, _ os.FileInfo) bool { return strings.Contains(p, "/internal/") },
 			func(p string, _ os.FileInfo) bool { return p == "rules/rules.go" },
 			func(p string, _ os.FileInfo) bool { return strings.HasSuffix(p, "_test.go") },
-			func(p string, _ os.FileInfo) bool { return aipIndex.MatchString(p) },
+			func(p string, _ os.FileInfo) bool { return aepIndex.MatchString(p) },
 		} {
 			if exempt(path, info) {
 				return nil
 			}
 		}
 
-		// This represents a rule. Get the AIP and rule name from the path.
+		// This represents a rule. Get the aep and rule name from the path.
 		match := ruleFile.FindStringSubmatch(path)
 		if match == nil {
 			errors = append(errors, fmt.Errorf("unexpected path: %s", path))
 			return nil
 		}
 
-		// Get the AIP number and final rule segment.
-		aip, err := strconv.Atoi(match[1])
+		// Get the aep number and final rule segment.
+		aep, err := strconv.Atoi(match[1])
 		if err != nil {
 			errors = append(errors, err)
 			return nil
 		}
 		name := strings.ReplaceAll(match[2], "_", "-")
-		token := fmt.Sprintf("%04d-%s", aip, name)
+		token := fmt.Sprintf("%04d-%s", aep, name)
 
 		// Run each checker and run up the list of errors.
 		for _, checker := range checkers {
-			if errs := checker(aip, name); len(errs) > 0 {
+			if errs := checker(aep, name); len(errs) > 0 {
 				errors = append(errors, errs...)
 				failedRules.Add(token)
 			}
@@ -120,6 +120,6 @@ func main() {
 }
 
 var (
-	ruleFile = regexp.MustCompile(`rules/aip([\d]{4})/([a-z0-9_]+).go`)
-	aipIndex = regexp.MustCompile(`rules/aip[\d]{4}/aip[\d]{4}\.go`)
+	ruleFile = regexp.MustCompile(`rules/aep([\d]{4})/([a-z0-9_]+).go`)
+	aepIndex = regexp.MustCompile(`rules/aep[\d]{4}/aep[\d]{4}\.go`)
 )

--- a/.github/quality-checker/rule_documented.go
+++ b/.github/quality-checker/rule_documented.go
@@ -19,9 +19,9 @@ import (
 	"os"
 )
 
-func checkRuleDocumented(aip int, name string) []error {
+func checkRuleDocumented(aep int, name string) []error {
 	// Ensure that the expected documentation file exists.
-	wantFile := fmt.Sprintf("docs/rules/%04d/%s.md", aip, name)
+	wantFile := fmt.Sprintf("docs/rules/%04d/%s.md", aep, name)
 	if _, err := os.ReadFile(wantFile); err != nil {
 		return []error{fmt.Errorf("missing rule documentation: %s", wantFile)}
 	}

--- a/.github/quality-checker/rule_name.go
+++ b/.github/quality-checker/rule_name.go
@@ -22,8 +22,8 @@ import (
 	"github.com/stoewer/go-strcase"
 )
 
-func checkRuleName(aip int, name string) []error {
-	path := fmt.Sprintf("rules/aip%04d/%s.go", aip, strcase.SnakeCase(name))
+func checkRuleName(aep int, name string) []error {
+	path := fmt.Sprintf("rules/aep%04d/%s.go", aep, strcase.SnakeCase(name))
 
 	// Read in the file.
 	contentsBytes, err := os.ReadFile(path)
@@ -36,13 +36,13 @@ func checkRuleName(aip int, name string) []error {
 	// If it can not be found, complain.
 	match := ruleNameRegexp.FindStringSubmatch(contents)
 	if match == nil {
-		return []error{fmt.Errorf("no rule name found: AIP-%d, %s", aip, name)}
+		return []error{fmt.Errorf("no rule name found: aep-%d, %s", aep, name)}
 	}
 
 	// If the rule name declaration does not match, complain.
 	errs := []error{}
-	if fmt.Sprintf("%d", aip) != match[1] {
-		errs = append(errs, fmt.Errorf("mismatch between path and rule AIP: %s", path))
+	if fmt.Sprintf("%d", aep) != match[1] {
+		errs = append(errs, fmt.Errorf("mismatch between path and rule aep: %s", path))
 	}
 	if name != match[2] {
 		errs = append(errs, fmt.Errorf("mismatch between rule name and filename: %s", path))

--- a/.github/quality-checker/rule_registered.go
+++ b/.github/quality-checker/rule_registered.go
@@ -23,8 +23,8 @@ import (
 	"github.com/stoewer/go-strcase"
 )
 
-func checkRuleRegistered(aip int, name string) []error {
-	path := fmt.Sprintf("rules/aip%04d/%s.go", aip, strcase.SnakeCase(name))
+func checkRuleRegistered(aep int, name string) []error {
+	path := fmt.Sprintf("rules/aep%04d/%s.go", aep, strcase.SnakeCase(name))
 
 	// Read in the file.
 	contents, err := os.ReadFile(path)
@@ -41,24 +41,24 @@ func checkRuleRegistered(aip int, name string) []error {
 	// Some errors are now non-fatal; start a running tab.
 	errata := []error{}
 
-	// Ensure this rule is registered within its AIP module file.
+	// Ensure this rule is registered within its aep module file.
 	ruleVar := ruleMatch[1]
-	contents, err = os.ReadFile(fmt.Sprintf("rules/aip%04d/aip%04d.go", aip, aip))
+	contents, err = os.ReadFile(fmt.Sprintf("rules/aep%04d/aep%04d.go", aep, aep))
 	if err != nil {
 		return []error{err}
 	}
 	if !strings.Contains(string(contents), ruleVar) {
-		errata = append(errata, fmt.Errorf("rule %q for AIP-%d not registered in the AIP's AllRules", name, aip))
+		errata = append(errata, fmt.Errorf("rule %q for aep-%d not registered in the aep's AllRules", name, aep))
 	}
 
-	// Ensure that the AIP itself is registered in `rules/rules.go`.
+	// Ensure that the aep itself is registered in `rules/rules.go`.
 	contents, err = os.ReadFile("rules/rules.go")
 	if err != nil {
 		errata = append(errata, err)
 		return errata
 	}
-	if !strings.Contains(string(contents), fmt.Sprintf("aip%04d.AddRules", aip)) {
-		errata = append(errata, fmt.Errorf("rules.go does not call AllRules for for AIP-%d", aip))
+	if !strings.Contains(string(contents), fmt.Sprintf("aep%04d.AddRules", aep)) {
+		errata = append(errata, fmt.Errorf("rules.go does not call AllRules for for aep-%d", aep))
 	}
 
 	// Done; return any errata we found.


### PR DESCRIPTION
The quality checker should reference AEPs instead.