### PR TITLE
Must rules cannot be disabled

### DIFF
--- a/lint/rule.go
+++ b/lint/rule.go
@@ -22,6 +22,15 @@ import (
 	dpb "google.golang.org/protobuf/types/descriptorpb"
 )
 
+type RuleType = int;
+
+const (
+	// TODO: Remove NotCategorized once all rules have categories.
+	NotCategorizedRule RuleType = iota
+	MustRule
+	ShouldRule
+)
+
 // ProtoRule defines a lint rule that checks Google Protobuf APIs.
 //
 // Anything that satisfies this interface can be used as a rule,
@@ -36,6 +45,9 @@ type ProtoRule interface {
 	// Lint accepts a FileDescriptor and lints it,
 	// returning a slice of Problem objects it finds.
 	Lint(*desc.FileDescriptor) []Problem
+
+	// GetRuleType returns the type of the rule.
+	GetRuleType() RuleType
 }
 
 // FileRule defines a lint rule that checks a file as a whole.
@@ -52,6 +64,16 @@ type FileRule struct {
 
 	//lint:ignore U1000 ignored via golint previously
 	noPositional struct{}
+
+	RuleType *RuleType
+}
+
+// GetRuleType returns the type of a rule.
+func (r *FileRule) GetRuleType() RuleType {
+	if(r.RuleType == nil) {
+		return NotCategorizedRule;
+	}
+	return *r.RuleType;
 }
 
 // GetName returns the name of the rule.
@@ -84,6 +106,16 @@ type MessageRule struct {
 
 	//lint:ignore U1000 ignored via golint previously
 	noPositional struct{}
+
+	RuleType *RuleType
+}
+
+// GetRuleType returns the type of a rule.
+func (r *MessageRule) GetRuleType() RuleType {
+	if(r.RuleType == nil) {
+		return NotCategorizedRule;
+	}
+	return *r.RuleType;
 }
 
 // GetName returns the name of the rule.
@@ -121,6 +153,16 @@ type FieldRule struct {
 
 	//lint:ignore U1000 ignored via golint previously
 	noPositional struct{}
+
+	RuleType *RuleType
+}
+
+// GetRuleType returns the type of a rule.
+func (r *FieldRule) GetRuleType() RuleType {
+	if(r.RuleType == nil) {
+		return NotCategorizedRule;
+	}
+	return *r.RuleType;
 }
 
 // GetName returns the name of the rule.
@@ -160,6 +202,16 @@ type ServiceRule struct {
 
 	//lint:ignore U1000 ignored via golint previously
 	noPositional struct{}
+
+	RuleType *RuleType
+}
+
+// GetRuleType returns the type of a rule.
+func (r *ServiceRule) GetRuleType() RuleType {
+	if(r.RuleType == nil) {
+		return NotCategorizedRule;
+	}
+	return *r.RuleType;
 }
 
 // GetName returns the name of the rule.
@@ -194,6 +246,16 @@ type MethodRule struct {
 
 	//lint:ignore U1000 ignored via golint previously
 	noPositional struct{}
+
+	RuleType *RuleType
+}
+
+// GetRuleType returns the type of a rule.
+func (r *MethodRule) GetRuleType() RuleType {
+	if(r.RuleType == nil) {
+		return NotCategorizedRule;
+	}
+	return *r.RuleType;
 }
 
 // GetName returns the name of the rule.
@@ -230,6 +292,16 @@ type EnumRule struct {
 
 	//lint:ignore U1000 ignored via golint previously
 	noPositional struct{}
+
+	RuleType *RuleType
+}
+
+// GetRuleType returns the type of a rule.
+func (r *EnumRule) GetRuleType() RuleType {
+	if(r.RuleType == nil) {
+		return NotCategorizedRule;
+	}
+	return *r.RuleType;
 }
 
 // GetName returns the name of the rule.
@@ -266,6 +338,16 @@ type EnumValueRule struct {
 
 	//lint:ignore U1000 ignored via golint previously
 	noPositional struct{}
+
+	RuleType *RuleType
+}
+
+// GetRuleType returns the type of a rule.
+func (r *EnumValueRule) GetRuleType() RuleType {
+	if(r.RuleType == nil) {
+		return NotCategorizedRule;
+	}
+	return *r.RuleType;
 }
 
 // GetName returns the name of the rule.
@@ -308,6 +390,16 @@ type DescriptorRule struct {
 
 	//lint:ignore U1000 ignored via golint previously
 	noPositional struct{}
+	
+	RuleType *RuleType
+}
+
+// GetRuleType returns the type of a rule.
+func (r *DescriptorRule) GetRuleType() RuleType {
+	if(r.RuleType == nil) {
+		return NotCategorizedRule;
+	}
+	return *r.RuleType;
 }
 
 // GetName returns the name of the rule.

--- a/lint/rule_enabled.go
+++ b/lint/rule_enabled.go
@@ -67,6 +67,10 @@ var descriptorDisableChecks = []func(d desc.Descriptor) bool{
 // augment the set of commentLines.
 func ruleIsEnabled(rule ProtoRule, d desc.Descriptor, l *dpb.SourceCodeInfo_Location,
 	aliasMap map[string]string, ignoreCommentDisables bool) bool {
+	if(rule.GetRuleType() == MustRule) {
+		return false;
+	}
+
 	// If the rule is disabled because of something on the descriptor itself
 	// (e.g. a deprecated annotation), address that.
 	for _, mustDisable := range descriptorDisableChecks {
@@ -98,6 +102,7 @@ func ruleIsEnabled(rule ProtoRule, d desc.Descriptor, l *dpb.SourceCodeInfo_Loca
 // ruleIsDisabledByComments returns true if the rule has been disabled
 // by comments in the file or leading the element.
 func ruleIsDisabledByComments(rule ProtoRule, d desc.Descriptor, l *dpb.SourceCodeInfo_Location, aliasMap map[string]string) bool {
+	// Must rules cannot be disabled by the linter.
 	// Some rules have a legacy name. We add it to the check list.
 	ruleName := string(rule.GetName())
 	names := []string{ruleName, aliasMap[ruleName]}
@@ -126,4 +131,10 @@ func ruleIsDisabledByComments(rule ProtoRule, d desc.Descriptor, l *dpb.SourceCo
 	}
 
 	return false
+}
+
+func NewRuleType(rt RuleType) *RuleType {
+	p := new(RuleType);
+	*p = rt;
+	return p;
 }


### PR DESCRIPTION
If a rule is a MustRule, the linter should not allow it to be disabled in any circumstance. 