### PR TITLE
Guidelines for Migrating AIP lint rules

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -150,6 +150,17 @@ git commit --allow-empty -m 'feat: new minor release'
 git commit --allow-empty -m 'fix: new patch release'
 ```
 
+## Migrating rules
+Rules in this linter need to be ported from the AIP standard to the AEP standard.
+
+When making a conversion PR, the following steps should be taken:
+
+1. Copy over new rules (and previously deleted rules) from the AIP linter.
+2. Change all references of the `name` field to `path` in the documentation.
+3. Remove any rules that no longer apply.
+4. For each existing AIP rule, check the AEPs and see what changes (if any) are necessary.
+5. Fix tests.
+
 <!-- prettier-ignore-start -->
 [aep]: https://aep.dev/
 [go]: https://golang.org/

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -151,6 +151,7 @@ git commit --allow-empty -m 'fix: new patch release'
 ```
 
 ## Migrating rules
+
 Rules in this linter need to be ported from the AIP standard to the AEP standard.
 
 When making a conversion PR, the following steps should be taken:

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -161,7 +161,7 @@ When making a conversion PR, the following steps should be taken:
 3. Remove any rules that no longer apply.
 4. For each existing AIP rule, check the AEPs and see what changes (if any) are necessary.
 5. Denote each rule with a Should/Must tag.
-6. Fix tests.
+6. Run tests with `go test ./...` and fix any issues.
 
 <!-- prettier-ignore-start -->
 [aep]: https://aep.dev/

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -159,7 +159,8 @@ When making a conversion PR, the following steps should be taken:
 2. Change all references of the `name` field to `path` in the documentation.
 3. Remove any rules that no longer apply.
 4. For each existing AIP rule, check the AEPs and see what changes (if any) are necessary.
-5. Fix tests.
+5. Denote each rule with a Should/Must tag.
+6. Fix tests.
 
 <!-- prettier-ignore-start -->
 [aep]: https://aep.dev/


### PR DESCRIPTION
This adds a list of guidelines for migrating AIP rules.