### PR TITLE
Resource messages should be identified by the 'path' field

### DIFF
--- a/rules/aep0004/aep0004.go
+++ b/rules/aep0004/aep0004.go
@@ -52,7 +52,7 @@ func isResourceMessage(m *desc.MessageDescriptor) bool {
 	// If the parent of this message is a message, it is nested and shoudn't
 	// be considered a resource, even if it has a name field.
 	_, nested := m.GetParent().(*desc.MessageDescriptor)
-	return m.FindFieldByName("name") != nil && !strings.HasSuffix(m.GetName(), "Request") &&
+	return m.FindFieldByName("path") != nil && !strings.HasSuffix(m.GetName(), "Request") &&
 		!strings.HasSuffix(m.GetName(), "Response") && !nested
 }
 

--- a/rules/aep0004/resource_annotation_test.go
+++ b/rules/aep0004/resource_annotation_test.go
@@ -30,7 +30,7 @@ func TestResourceAnnotation(t *testing.T) {
 					type: "library.googleapis.com/Book"
 					pattern: "publishers/{publisher}/books/{book}"
 				};
-				string name = 1;
+				string path = 1;
 			}
 		`)
 		if diff := (testutils.Problems{}).Diff(resourceAnnotation.Lint(f)); diff != "" {
@@ -42,7 +42,7 @@ func TestResourceAnnotation(t *testing.T) {
 		f := testutils.ParseProto3String(t, `
 			message Foo {
 				message Bar {
-					string name = 1;
+					string path = 1;
 				}
 				Bar bar = 1;
 			}
@@ -61,9 +61,9 @@ func TestResourceAnnotation(t *testing.T) {
 		problems    testutils.Problems
 	}{
 		{"ValidNoNameField", "Book", "title", testutils.Problems{}},
-		{"ValidRequestMessage", "GetBookRequest", "name", testutils.Problems{}},
-		{"ValidResponseMessage", "GetBookResponse", "name", testutils.Problems{}},
-		{"Invalid", "Book", "name", testutils.Problems{{Message: "google.api.resource"}}},
+		{"ValidRequestMessage", "GetBookRequest", "path", testutils.Problems{}},
+		{"ValidResponseMessage", "GetBookResponse", "path", testutils.Problems{}},
+		{"Invalid", "Book", "path", testutils.Problems{{Message: "google.api.resource"}}},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			f := testutils.ParseProto3Tmpl(t, `


### PR DESCRIPTION
Fixes #92 

We should identify resource messages by the "path" field, not the "name" field.