### PR TITLE
fix literal regexp in http template

### DIFF
--- a/rules/aep0127/http_template_syntax.go
+++ b/rules/aep0127/http_template_syntax.go
@@ -25,7 +25,7 @@ import (
 )
 
 var (
-	literal          = `(\w+)`
+	literal          = `([a-z]([a-z0-9\-_]*[a-z0-9])?)`
 	identifier       = `(\w+)`
 	verb             = fmt.Sprintf("(:%s)", literal)
 	fieldPath        = fmt.Sprintf(`(%s(\.%s)*)`, identifier, identifier)

--- a/rules/aep0127/http_template_syntax_test.go
+++ b/rules/aep0127/http_template_syntax_test.go
@@ -35,6 +35,7 @@ func TestHttpTemplateSyntax(t *testing.T) {
 		{"VersionedTemplate", "/{$api_version}/books", true},
 		{"TwoLiterals", "/v1/books", true},
 		{"ThreeLiterals", "/v1/books/shelves", true},
+		{"KebabCaseLiteral", "/user-events", true},
 		{"SingleLiteralWithVerb", "/v1:verb", true},
 		{"MultipleLiteralsWithVerb", "/v1/books:verb", true},
 		{"SingleWildcard", "/v1/*", true},
@@ -55,6 +56,7 @@ func TestHttpTemplateSyntax(t *testing.T) {
 		{"VariableWithDoubleWildcardFollowedByLiteral", "/v1/{field=**/books}", true},
 		{"VariableWithLiteralFollowedBySingleWildcard", "/v1/{field=books/*}", true},
 		{"VariableWithLiteralFollowedByDoubleWildcard", "/v1/{field=books/**}", true},
+		{"VariableWithKebabCaseLiteralFollowedBySingleWildcard", "/v1/{field=user-events/*}", true},
 		{"VariableFollowedByLiteral", "/v1/{field}/books", true},
 		{"VariableFollowedByVariable", "/v1/{field}/{otherField}", true},
 		{"VariableWithTemplateFollowedByLiteral", "/v1/{field=books/*}/shelves", true},
@@ -64,7 +66,6 @@ func TestHttpTemplateSyntax(t *testing.T) {
 		// Invalid cases
 		{"LiteralWithoutLeadingSlash", "v1", false},
 		{"LiteralFollowedBySlash", "/v1/", false},
-		{"WrongVerbDelimiter", "/v1-verb", false},
 		{"MultipleVerbs", "/v1:verb:verb", false},
 		{"VerbFollowedBySlash", "/v1:verb/", false},
 		{"MultipleLiteralsWithWrongDelimiter", "/v1|books", false},


### PR DESCRIPTION
The `aep.dev/4` uses kebab-case for resource types so the api-linter should allow `-` in the literal of http template.

This PR modifies the regexp of literal to allow kebab-case.